### PR TITLE
Make jest peer dependency more lenient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-auto-snapshots",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Fully automated Jest snapshot tests for React components",
   "main": "./dist/index.js",
   "repository": "git@github.com:icd2k3/jest-auto-snapshots.git",
@@ -13,7 +13,7 @@
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.2.2",
-    "jest": "^21.2.1",
+    "jest": ">= 21.2.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },


### PR DESCRIPTION
Jest is currently on major version 23, so this peer dependency causes a warning to show up when updating dependencies:

```
warning " > jest-auto-snapshots@2.1.2" has incorrect peer dependency "jest@^21.2.1".
```