### PR TITLE
be more lenient about node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "jest-auto-snapshots",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Fully automated Jest snapshot tests for React components",
   "main": "./dist/index.js",
   "repository": "git@github.com:icd2k3/jest-auto-snapshots.git",
   "author": "JUSTIN SCHRADER <icd2k3@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": "8.11.3"
+    "node": ">= 8.11.3"
   },
   "peerDependencies": {
     "enzyme": "^3.2.0",


### PR DESCRIPTION
When on node 10.8.0, the following error shows up during dependency installation:

```
error jest-auto-snapshots@2.1.3: The engine "node" is incompatible with this module. Expected version "8.11.3".
error Found incompatible module
```